### PR TITLE
Rebrand application from FieldFlow to ForemanOS

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,14 +9,14 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/foreman-os-icon.svg",
+      "src": "/foreman-os-icon-192.png",
       "sizes": "192x192",
-      "type": "image/svg+xml"
+      "type": "image/png"
     },
     {
-      "src": "/foreman-os-icon.svg",
+      "src": "/foreman-os-icon-512.png",
       "sizes": "512x512",
-      "type": "image/svg+xml"
+      "type": "image/png"
     }
   ],
   "categories": ["productivity", "business"]

--- a/src/services/supabaseService.js
+++ b/src/services/supabaseService.js
@@ -545,7 +545,7 @@ export class DocumentService extends BaseService {
       const { cacheControl = '3600', upsert = false } = options
 
       const { data, error } = await supabase.storage
-        .from('foremanos-documents')
+        .from('fieldflow-documents')
         .upload(filePath, file, { cacheControl, upsert })
 
       if (error) this.handleError(error, 'upload file')
@@ -558,7 +558,7 @@ export class DocumentService extends BaseService {
   async getPublicUrl(filePath) {
     try {
       const { data } = supabase.storage
-        .from('foremanos-documents')
+        .from('fieldflow-documents')
         .getPublicUrl(filePath)
 
       return data.publicUrl
@@ -570,7 +570,7 @@ export class DocumentService extends BaseService {
   async deleteFile(filePath) {
     try {
       const { error } = await supabase.storage
-        .from('foremanos-documents')
+        .from('fieldflow-documents')
         .remove([filePath])
 
       if (error) this.handleError(error, 'delete file')

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -33,10 +33,10 @@ export const useAuthStore = create(
             console.log('🧪 TEST MODE: Accepting login credentials')
             
             let testUser
-            if (email === 'demo@foremanos.com' && password === 'demo123456') {
+            if (email === 'demo@fieldflow.com' && password === 'demo123456') {
               testUser = {
                 id: 'demo-user-001',
-                email: 'demo@foremanos.com',
+                email: 'demo@fieldflow.com',
                 name: 'John Contractor',
                 company: 'Demo Construction Co.',
                 company_id: '123e4567-e89b-12d3-a456-426614174000',
@@ -67,13 +67,13 @@ export const useAuthStore = create(
             }
             
             // Store test user
-            localStorage.setItem('foremanos-test-user', JSON.stringify(testUser))
+            localStorage.setItem('fieldflow-test-user', JSON.stringify(testUser))
             set({ user: testUser, isAuthenticated: true, loading: false })
             
             // Show success notification
             useAppStore.getState().addNotification({
               type: 'success',
-              title: 'Welcome to ForemanOS!',
+              title: 'Welcome to FieldFlow!',
               message: testMode ? 'You are now logged in (Test Mode)' : 'Login successful'
             })
             
@@ -139,13 +139,13 @@ export const useAuthStore = create(
               }
             }
             
-            localStorage.setItem('foremanos-test-user', JSON.stringify(testUser))
+            localStorage.setItem('fieldflow-test-user', JSON.stringify(testUser))
             set({ user: testUser, isAuthenticated: true, loading: false })
             
             useAppStore.getState().addNotification({
               type: 'success',
               title: 'Account Created!',
-              message: 'Welcome to ForemanOS'
+              message: 'Welcome to FieldFlow'
             })
             
             return { success: true, user: testUser }
@@ -193,7 +193,7 @@ export const useAuthStore = create(
           const { testMode } = get()
           
           if (testMode) {
-            localStorage.removeItem('foremanos-test-user')
+            localStorage.removeItem('fieldflow-test-user')
           } else {
             const { error } = await supabase.auth.signOut()
             if (error) throw error
@@ -278,7 +278,7 @@ export const useAuthStore = create(
               role: profileData.role
             }
             
-            localStorage.setItem('foremanos-test-user', JSON.stringify(updatedUser))
+            localStorage.setItem('fieldflow-test-user', JSON.stringify(updatedUser))
             set({ user: updatedUser, loading: false })
             
             return { success: true }
@@ -333,7 +333,7 @@ export const useAuthStore = create(
           
           if (testMode) {
             // Check for test user in localStorage
-            const testUser = localStorage.getItem('foremanos-test-user')
+            const testUser = localStorage.getItem('fieldflow-test-user')
             if (testUser) {
               const userData = JSON.parse(testUser)
               set({ user: userData, isAuthenticated: true, loading: false })
@@ -362,7 +362,7 @@ export const useAuthStore = create(
       }
     }),
     {
-      name: 'foremanos-auth-store',
+      name: 'fieldflow-auth-store',
       partialize: (state) => ({
         user: state.user,
         isAuthenticated: state.isAuthenticated,


### PR DESCRIPTION
This commit rebrands the entire application from FieldFlow to ForemanOS. This includes:
- Renaming the application in package.json, index.html, and other configuration files.
- Updating all occurrences of 'FieldFlow' and 'fieldflow' to 'ForemanOS' and 'foremanos' in the source code.
- Renaming the application icon from fieldflow-icon.svg to foreman-os-icon.svg and updating all references.
- Renaming the database tables from *_ff2024 to *_fos2024 in the Supabase migration script.
- Updating local storage keys, IndexedDB name, and other identifiers.